### PR TITLE
Fix build due to symlinked dir with a dune file

### DIFF
--- a/example/dynamic.ml
+++ b/example/dynamic.ml
@@ -16,7 +16,7 @@ module Merlin =
         "Unix";
         "UnixLabels";
       ] in
-      let dcs_url = "/static/stdlib/" in
+      let dcs_url = "/stdlib/" in
       let dcs_file_prefixes = ["stdlib__"] in
     { Protocol.static_cmis = [];
       dynamic_cmis = Some {

--- a/example/static
+++ b/example/static
@@ -1,1 +1,0 @@
-../src/worker/static

--- a/example/stdlib
+++ b/example/stdlib
@@ -1,0 +1,1 @@
+../src/worker/static/stdlib


### PR DESCRIPTION
Dune was getting confused by there being a symlink to a directory containing a dune file. Fix by symlinking a subdirectory instead.