### PR TITLE
Fix generation of static cmis to match protocol

### DIFF
--- a/example/dynamic.ml
+++ b/example/dynamic.ml
@@ -16,7 +16,7 @@ module Merlin =
         "Unix";
         "UnixLabels";
       ] in
-      let dcs_url = "/stdlib/" in
+      let dcs_url = "stdlib/" in
       let dcs_file_prefixes = ["stdlib__"] in
     { Protocol.static_cmis = [];
       dynamic_cmis = Some {

--- a/src/worker/static/gen_static.ml
+++ b/src/worker/static/gen_static.ml
@@ -19,7 +19,7 @@ let () =
   let dir = Unix.opendir stdlib in
   iter_cmi ~f:(fun file ->
     let fullpath = Filename.concat stdlib file in
-    let module_name = Filename.basename file |> String.capitalize_ascii in
+    let module_name = Filename.basename file |> String.capitalize_ascii |> Filename.remove_extension in
     Printf.fprintf out "{sc_name=%S; sc_content=[%%blob %S]};" module_name fullpath) dir;
     Printf.fprintf out "]\n";
 


### PR DESCRIPTION
protocol.ml states:

```ocaml
type static_cmi = {
  sc_name : string; (* capitalised, e.g. 'Stdlib' *)
  sc_content : string;
}
```

but the `gen_static` script was generating:

```ocaml
{sc_name="Stdlib__Buffer.cmi"; sc_content=[%blob ...
```

Fix is to strip the extension.