### PR TITLE
Allow protocol extensions

### DIFF
--- a/src/client/merlin_client.ml
+++ b/src/client/merlin_client.ml
@@ -1,77 +1,91 @@
-open Brr
-module Worker = Brr_webworkers.Worker
+module type WORKER = sig
+  type t
+  val post : t -> Protocol.action -> unit
+end
 
-(* When a query is sent to the Worker we keep the Future result in an indexed
-table so that the on_message function will be able to determine the Future when
-the answer is posted by the Worker.
-The Worker works synchronously so we expect answer to arrive in order. *)
-type worker = {
-  worker: Worker.t;
-  queue: (Protocol.answer -> unit) Queue.t
-}
+module Make (Worker : WORKER) = struct
+  (* When a query is sent to the Worker we keep the Future result in an indexed
+  table so that the on_message function will be able to determine the Future when
+  the answer is posted by the Worker.
+  The Worker works synchronously so we expect answer to arrive in order. *)
+  type worker = {
+    worker: Worker.t;
+    queue: (Protocol.answer -> unit) Queue.t
+  }
 
-let add_fut worker res = Queue.add res worker.queue
-let res_fut worker v = (Queue.take worker.queue) v
+  let add_fut worker res = Queue.add res worker.queue
+  let res_fut worker v = (Queue.take worker.queue) v
+
+  let on_message worker data = res_fut worker data
+
+  let make_worker worker =
+    let queue = Queue.create () in
+    { worker; queue }
+
+  (* todo share that with worker *)
+  type action = Completion | Type_enclosing | Errors
+
+  type errors = Protocol.error list
+
+  let query ~action worker (*todo: other queries*) =
+    let fut, set  = Fut.create () in
+    add_fut worker set;
+    Worker.post worker.worker action;
+    fut
+
+  let query_errors worker (source : string) =
+    let open Fut.Syntax in
+    let action = Protocol.All_errors source in
+    let+ data : Protocol.answer = query ~action worker in
+    match data with
+    | Protocol.Errors errors -> errors
+    | _ -> assert false
+
+  let query_completions worker (source : string) position =
+    let open Fut.Syntax in
+    let action = Protocol.Complete_prefix (source, position) in
+    let+ data : Protocol.answer = query ~action worker in
+    match data with
+    | Protocol.Completions compl -> compl
+    | _ -> assert false
+
+  let query_type worker (source : string) position =
+    let open Fut.Syntax in
+    let action = Protocol.Type_enclosing (source, position) in
+    let+ data : Protocol.answer = query ~action worker in
+    match data with
+    | Protocol.Typed_enclosings l -> l
+    | _ -> assert false
+
+  let add_cmis worker cmis =
+    let open Fut.Syntax in
+    let action = Protocol.Add_cmis cmis in
+    let+ data : Protocol.answer = query ~action worker in
+    match data with
+    | Protocol.Added_cmis -> ()
+    | _ -> assert false
+end
+
+module Webworker = struct
+  include Brr_webworkers.Worker
+
+  let post t action =
+    let bytes = Marshal.to_bytes action [] in
+    post t bytes
+end
+
+include Make (Webworker)
 
 let make_worker url =
-  let worker = Worker.create @@ Jstr.of_string url in
-  let queue = Queue.create () in
-  let worker = { worker; queue } in
+  let worker = make_worker @@ Webworker.create @@ Jstr.of_string url in
   let on_message m =
-    let m = Ev.as_type m in
+    let m = Brr.Ev.as_type m in
     let data_marshaled : bytes = Brr_io.Message.Ev.data m in
     let data : Protocol.answer = Marshal.from_bytes data_marshaled 0 in
-    res_fut worker data
+    on_message worker data
   in
-  let _listener =
-    Ev.listen Brr_io.Message.Ev.message on_message @@
-      Worker.as_target worker.worker
+  let _listen =
+    Brr.Ev.listen Brr_io.Message.Ev.message on_message
+    @@ Webworker.as_target worker.worker
   in
   worker
-
-(* todo share that with worker *)
-type action = Completion | Type_enclosing | Errors
-
-type errors = Protocol.error list
-
-let query ~action worker (*todo: other queries*) =
-  let fut, set  = Fut.create () in
-  add_fut worker set;
-  Worker.post worker.worker (Marshal.to_bytes action []);
-  fut
-
-let query_errors worker (source : string) =
-  let open Fut.Syntax in
-  let action = Protocol.All_errors source in
-  let+ data : Protocol.answer = query ~action worker in
-  Console.(log ["Received errors:";  data]);
-  match data with
-  | Protocol.Errors errors -> errors
-  | _ -> assert false
-
-let query_completions worker (source : string) position =
-  let open Fut.Syntax in
-  let action = Protocol.Complete_prefix (source, position) in
-  let+ data : Protocol.answer = query ~action worker in
-  Console.(log ["Received completions:";  data]);
-  match data with
-  | Protocol.Completions compl -> compl
-  | _ -> assert false
-
-let query_type worker (source : string) position =
-  let open Fut.Syntax in
-  let action = Protocol.Type_enclosing (source, position) in
-  let+ data : Protocol.answer = query ~action worker in
-  Console.(log ["Received typed enclosings:";  data]);
-  match data with
-  | Protocol.Typed_enclosings l -> l
-  | _ -> assert false
-
-let add_cmis worker cmis =
-  let open Fut.Syntax in
-  let action = Protocol.Add_cmis cmis in
-  let+ data : Protocol.answer = query ~action worker in
-  Console.(log ["Received response from adding cmis:";  data]);
-  match data with
-  | Protocol.Added_cmis -> ()
-  | _ -> assert false

--- a/src/extension/merlin_codemirror.ml
+++ b/src/extension/merlin_codemirror.ml
@@ -3,81 +3,95 @@ open Brr
 
 module Utils = Utils
 
-let linter worker = fun view ->
-  let open Fut.Syntax in
-  let doc = Utils.get_full_doc @@ Editor.View.state view in
-  let+ result = Merlin_client.query_errors worker doc in
-  List.map (fun Protocol.{ kind; loc; main; sub = _; source } ->
-    let from = loc.loc_start.pos_cnum in
-    let to_ = loc.loc_end.pos_cnum in
-    let source = Protocol.report_source_to_string source in
-    let severity = match kind with
-      | Report_error
-      | Report_warning_as_error _
-      | Report_alert_as_error _ -> Lint.Diagnostic.Error
-      | Report_warning _ -> Lint.Diagnostic.Warning
-      | Report_alert _ -> Lint.Diagnostic.Info
-    in
-    Lint.Diagnostic.create ~source ~from ~to_ ~severity ~message:main ()
-  ) result
-  |> Array.of_list
-
-let keywords = List.map
-  (fun label ->
-    Autocomplete.Completion.create ~label ~type_:"keyword" ())
-    [
-      "as"; "do"; "else"; "end"; "exception"; "fun"; "functor"; "if"; "in";
-      "include"; "let"; "of"; "open"; "rec"; "struct"; "then"; "type"; "val";
-      "while"; "with"; "and"; "assert"; "begin"; "class"; "constraint";
-      "done"; "downto"; "external"; "function"; "initializer"; "lazy";
-      "match"; "method"; "module"; "mutable"; "new"; "nonrec"; "object";
-      "private"; "sig"; "to"; "try"; "value"; "virtual"; "when";
-    ]
-
-let merlin_completion worker = fun ctx ->
-  let open Fut.Syntax in
-  let source = Utils.get_full_doc @@ Autocomplete.Context.state ctx in
-  let pos = Autocomplete.Context.pos ctx in
-  let+ { from; to_; entries } =
-    Merlin_client.query_completions worker source (`Offset pos)
-  in
-  let options =
-    let num_completions = List.length entries in
-    List.mapi (fun i Query_protocol.Compl.{ name; desc; _ } ->
-      let boost = num_completions - i in
-      Autocomplete.Completion.create ~label:name ~detail:desc ~boost ()) entries
-  in
-  Some (Autocomplete.Result.create ~filter:true ~from ~to_ ~options ())
-
-let autocomplete worker =
-  let override = [
-    Autocomplete.Source.from_list keywords;
-    Autocomplete.Source.create @@ merlin_completion worker]
-in
-  let config = Autocomplete.config () ~override in
-  Autocomplete.create ~config ()
-
-let tooltip_on_hover worker =
-  let open Tooltip in
-  hover_tooltip @@
-  fun ~view ~pos ~side:_ ->
-    let open Fut.Syntax in
-    let doc = Utils.get_full_doc @@ Editor.View.state view in
-    let pos = `Offset pos in
-    let+ result = Merlin_client.query_type worker doc pos in
-    match result with
-    | (loc, `String type_, _)::_ ->
-      let create _view =
-        let dom = El.div [El.txt' type_] in
-        Tooltip_view.create ~dom ()
-      in
-      let pos = loc.loc_start.pos_cnum in
-      let end_ = loc.loc_end.pos_cnum in
-      Some (Tooltip.create ~pos ~end_ ~above:true ~arrow:true ~create ())
-    | _ -> None
-
 let ocaml = Jv.get Jv.global "__CM__mllike" |> Stream.Language.of_jv
 let ocaml = Stream.Language.define ocaml
+
+module Extensions (Worker : Merlin_client.WORKER) = struct
+
+  module Merlin_client = Merlin_client.Make (Worker)
+  type worker = Merlin_client.worker
+
+  let linter worker = fun view ->
+    let open Fut.Syntax in
+    let doc = Utils.get_full_doc @@ Editor.View.state view in
+    let+ result = Merlin_client.query_errors worker doc in
+    List.map (fun Protocol.{ kind; loc; main; sub = _; source } ->
+      let from = loc.loc_start.pos_cnum in
+      let to_ = loc.loc_end.pos_cnum in
+      let source = Protocol.report_source_to_string source in
+      let severity = match kind with
+        | Report_error
+        | Report_warning_as_error _
+        | Report_alert_as_error _ -> Lint.Diagnostic.Error
+        | Report_warning _ -> Lint.Diagnostic.Warning
+        | Report_alert _ -> Lint.Diagnostic.Info
+      in
+      Lint.Diagnostic.create ~source ~from ~to_ ~severity ~message:main ()
+    ) result
+    |> Array.of_list
+
+  let keywords = List.map
+    (fun label ->
+      Autocomplete.Completion.create ~label ~type_:"keyword" ())
+      [
+        "as"; "do"; "else"; "end"; "exception"; "fun"; "functor"; "if"; "in";
+        "include"; "let"; "of"; "open"; "rec"; "struct"; "then"; "type"; "val";
+        "while"; "with"; "and"; "assert"; "begin"; "class"; "constraint";
+        "done"; "downto"; "external"; "function"; "initializer"; "lazy";
+        "match"; "method"; "module"; "mutable"; "new"; "nonrec"; "object";
+        "private"; "sig"; "to"; "try"; "value"; "virtual"; "when";
+      ]
+
+  let merlin_completion worker = fun ctx ->
+    let open Fut.Syntax in
+    let source = Utils.get_full_doc @@ Autocomplete.Context.state ctx in
+    let pos = Autocomplete.Context.pos ctx in
+    let+ { from; to_; entries } =
+      Merlin_client.query_completions worker source (`Offset pos)
+    in
+    let options =
+      let num_completions = List.length entries in
+      List.mapi (fun i Query_protocol.Compl.{ name; desc; _ } ->
+        let boost = num_completions - i in
+        Autocomplete.Completion.create ~label:name ~detail:desc ~boost ()) entries
+    in
+    Some (Autocomplete.Result.create ~filter:true ~from ~to_ ~options ())
+
+  let autocomplete worker =
+    let override = [
+      Autocomplete.Source.from_list keywords;
+      Autocomplete.Source.create @@ merlin_completion worker]
+  in
+    let config = Autocomplete.config () ~override in
+    Autocomplete.create ~config ()
+
+  let tooltip_on_hover worker =
+    let open Tooltip in
+    hover_tooltip @@
+    fun ~view ~pos ~side:_ ->
+      let open Fut.Syntax in
+      let doc = Utils.get_full_doc @@ Editor.View.state view in
+      let pos = `Offset pos in
+      let+ result = Merlin_client.query_type worker doc pos in
+      match result with
+      | (loc, `String type_, _)::_ ->
+        let create _view =
+          let dom = El.div [El.txt' type_] in
+          Tooltip_view.create ~dom ()
+        in
+        let pos = loc.loc_start.pos_cnum in
+        let end_ = loc.loc_end.pos_cnum in
+        Some (Tooltip.create ~pos ~end_ ~above:true ~arrow:true ~create ())
+      | _ -> None
+
+  let linter worker = Lint.create (linter worker)
+
+  let all_extensions worker = [|
+    linter worker;
+    autocomplete worker;
+    tooltip_on_hover worker
+  |]
+end
 
 module type Config = sig
   val worker_url : string
@@ -90,13 +104,10 @@ module Make (Config : Config) = struct
     let _ = Merlin_client.add_cmis worker Config.cmis in
     worker
 
+  open Extensions (Merlin_client.Webworker)
+
   let autocomplete = autocomplete worker
   let tooltip_on_hover = tooltip_on_hover worker
-  let linter = Lint.create (linter worker)
-
-  let all_extensions = [|
-    linter;
-    autocomplete;
-    tooltip_on_hover
-  |]
+  let linter = linter worker
+  let all_extensions = all_extensions worker
 end

--- a/src/extension/merlin_codemirror.mli
+++ b/src/extension/merlin_codemirror.mli
@@ -18,6 +18,7 @@ module type Config = sig
 end
 
 module Make : functor (Config : Config) -> sig
+
   val autocomplete : Code_mirror.Extension.t
   (** An extension providing completions when typing *)
 
@@ -29,4 +30,23 @@ module Make : functor (Config : Config) -> sig
 
   val all_extensions : Code_mirror.Extension.t array
   (** All the Merlin-specific extensions (does not include [ocaml]) *)
+
+end
+
+module Extensions (Worker : Merlin_client.WORKER) : sig
+
+  type worker = Merlin_client.Make(Worker).worker
+
+  val autocomplete : worker -> Code_mirror.Extension.t
+  (** An extension providing completions when typing *)
+
+  val tooltip_on_hover : worker -> Code_mirror.Extension.t
+  (** An extension providing type-information when hovering code *)
+
+  val linter : worker -> Code_mirror.Extension.t
+  (** An extension that highlights errors and warnings in the code *)
+
+  val all_extensions : worker -> Code_mirror.Extension.t array
+  (** All the Merlin-specific extensions (does not include [ocaml]) *)
+
 end

--- a/src/worker/worker.ml
+++ b/src/worker/worker.ml
@@ -204,58 +204,54 @@ let dump () =
     Mconfig.dump (Mpipeline.final_config pipeline)
     |> Json.pretty_to_string *)
 
-let on_message marshaled_message =
-  let action : Protocol.action =
-    Marshal.from_bytes marshaled_message 0
-  in
-  let res =
-    match action with
-    | Complete_prefix (source, position) ->
-      let source = Msource.make source in
-      begin match Completion.at_pos source position with
-      | Some (from, to_, compl) ->
-        let entries = compl.entries in
-        Protocol.Completions { from; to_; entries; }
-      | None ->
-        Protocol.Completions { from = 0; to_ = 0; entries = []; }
-      end
-    | Type_enclosing (source, position) ->
-      let source = Msource.make source in
-      let query = Query_protocol.Type_enclosing (None, position, None) in
-      Protocol.Typed_enclosings (dispatch source query)
-    | Protocol.All_errors source ->
-        let source = Msource.make source in
-        let query = Query_protocol.Errors {
-            lexing = true;
-            parsing = true;
-            typing = true;
-          }
+let on_message = function
+  | Protocol.Complete_prefix (source, position) ->
+    let source = Msource.make source in
+    begin match Completion.at_pos source position with
+    | Some (from, to_, compl) ->
+      let entries = compl.entries in
+      Protocol.Completions { from; to_; entries; }
+    | None ->
+      Protocol.Completions { from = 0; to_ = 0; entries = []; }
+    end
+  | Type_enclosing (source, position) ->
+    let source = Msource.make source in
+    let query = Query_protocol.Type_enclosing (None, position, None) in
+    Protocol.Typed_enclosings (dispatch source query)
+  | Protocol.All_errors source ->
+    let source = Msource.make source in
+    let query = Query_protocol.Errors {
+        lexing = true;
+        parsing = true;
+        typing = true;
+      }
+    in
+    let errors =
+      dispatch source query
+      |> List.map ~f:(fun (Location.{kind; main=_ ; sub; source; _} as error) ->
+        let of_sub sub =
+            Location.print_sub_msg Format.str_formatter sub;
+            String.trim (Format.flush_str_formatter ())
         in
-        let errors =
-          dispatch source query
-          |> List.map ~f:(fun (Location.{kind; main=_ ; sub; source; _} as error) ->
-            let of_sub sub =
-                Location.print_sub_msg Format.str_formatter sub;
-                String.trim (Format.flush_str_formatter ())
-            in
-            let loc = Location.loc_of_report error in
-            let main =
-              Format.asprintf "@[%a@]" Location.print_main error |> String.trim
-            in
-            Protocol.{
-              kind;
-              loc;
-              main;
-              sub = List.map ~f:of_sub sub;
-              source;
-          })
+        let loc = Location.loc_of_report error in
+        let main =
+          Format.asprintf "@[%a@]" Location.print_main error |> String.trim
         in
-        Protocol.Errors errors
-    | Add_cmis cmis ->
-        add_cmis cmis
-  in
-  let res = Marshal.to_bytes res [] in
-  Js_of_ocaml.Worker.post_message res
+        Protocol.{
+          kind;
+          loc;
+          main;
+          sub = List.map ~f:of_sub sub;
+          source;
+      })
+    in
+    Protocol.Errors errors
+  | Add_cmis cmis ->
+    add_cmis cmis
 
 let run () =
-  Js_of_ocaml.Worker.set_onmessage on_message
+  Js_of_ocaml.Worker.set_onmessage @@ fun marshaled_message ->
+  let action : Protocol.action = Marshal.from_bytes marshaled_message 0 in
+  let res = on_message action in
+  let res = Marshal.to_bytes res [] in
+  Js_of_ocaml.Worker.post_message res

--- a/src/worker/worker.mli
+++ b/src/worker/worker.mli
@@ -1,1 +1,2 @@
+val on_message : Protocol.action -> Protocol.answer
 val run : unit -> unit


### PR DESCRIPTION
I would like to extend the Merlin worker with additional custom protocol messages (unrelated to merlin). This PR introduces some dependency injection for the Brr Webworker to allow redefining how the Merlin client sends its messages to its worker. It also exposes the worker `on_message` handler (instead of just the `run ()` function). The diff ends up rather large due to the introduction of functors and their extra indentation, but it should be backward compatible.